### PR TITLE
some suggestions for fixes and best practices

### DIFF
--- a/common/models/items.js
+++ b/common/models/items.js
@@ -16,7 +16,7 @@ module.exports = function(Items) {
       var data, callback;
       if (arguments && arguments.length>0) {
         data = arguments[0];
-        var possibleCallbackArg = arguments[arguments.length-1]
+        var possibleCallbackArg = arguments[arguments.length-1];
         if (typeof possibleCallbackArg === 'function') {
           callback = possibleCallbackArg;
         }
@@ -26,23 +26,23 @@ module.exports = function(Items) {
 
       callback = callback || utils.createPromiseCallback();
 
-      // get current context
-      var currentContext = loopback.getCurrentContext();
-      if (currentContext)  {
-        // get current user id
-        var currentUser = currentContext.get('currentUser');
-        // get current user org id
-        var organisation = currentContext.get('organisation');
-        data.orgId = organisation.id; // TODO: probably a related method call will do this for you, so don't need to override?
-        data.creatorId = currentUser.id; // TODO: probably a related method call won't do this for you, so override has some merit
-        return originalCreate.call(self, arguments);
-      }
-      else {
-        return originalCreate.call(self, arguments);
-      }
+	      	// get current context
+	      	var currentContext = loopback.getCurrentContext();
+	      	if (currentContext)  {
+		        // get current user id
+		        var currentUser = currentContext.get('currentUser');
+		        // get current user org id
+		        var organisation = currentContext.get('organisation');
+		        data.orgId = organisation.id; // TODO: probably a related method call will do this for you, so don't need to override?
+		        data.creatorId = currentUser.id; // TODO: probably a related method call won't do this for you, so override has some merit
+		        return originalCreate.apply(self, arguments);
+	    	}
+		    else {
+		    	return originalCreate.apply(self, arguments);
+		    }
 
-      return callback.promise;
-		};
+	    return callback.promise;
+	};
 	});
 
 

--- a/common/models/items.js
+++ b/common/models/items.js
@@ -4,52 +4,35 @@ var utils = require('loopback-datasource-juggler/lib/utils');
 var _ = require('underscore');
 
 module.exports = function(Items) {
-	
+
 	Items.on('dataSourceAttached',function(obj){
-		var override = Items.create;
+		var originalCreate = Items.create;
 		/*
 		* Override the create mehtod to check for valid user and org
 		* Allow if creatorId is same as current user id
 		* Allow if orgId is same as current user organisation
 		*/
-		Items.create = function(credentials,filters,callback){
+		Items.create = function(data, callback){
 			var self = this;
 
-			if (typeof include === 'function') {
-				callback = filters;
-				filters = undefined;
-			}
-
 			callback = callback || utils.createPromiseCallback();
-			// Get the mongodb _id object.
-			var error;
-			var mongoDs = Items.app.datasources.mongoDs;
- 			var ObjectID = mongoDs.connector.getDefaultIdType();
- 			// get current context
-			var currentContext = loopback.getCurrentContext();
-			// get current user id 
-			var currentUser = currentContext.get('currentUser');
-			// get current user org id
-			var organisation = currentContext.get('organisation'); 
-			/*
-			* Check if the user is same as passed in the credentials
-			* Check if the current user org is same as the credentials org
-			*/
-			var equalOrg = _.isEqual(new ObjectID(credentials.orgId),organisation.id);
-			var equalUsr = _.isEqual(new ObjectID(credentials.creatorId),currentUser);
-			if(equalOrg && equalUsr){
-				Promise.resolve().then(function(){
-					override.call(self, credentials, filters, callback);
-				})
-				.catch(callback);
-			}
-			else{
-				console.log('error');
-				error = new Error('Invalid credentials');
-				error.status = 404;
-				callback(error);
-			}
-			return callback.$promise;
+
+      // get current context
+      var currentContext = loopback.getCurrentContext();
+      if (currentContext)  {
+        // get current user id
+        var currentUser = currentContext.get('currentUser');
+        // get current user org id
+        var organisation = currentContext.get('organisation');
+        data.orgId = organisation.id; // TODO: probably a related method call will do this for you, so don't need to override?
+        data.creatorId = currentUser.id; // TODO: probably a related method call won't do this for you, so override has some merit
+        return originalCreate.call(self, arguments);
+      }
+      else {
+        return originalCreate.call(self, arguments);
+      }
+
+      return callback.promise;
 		};
 	});
 

--- a/common/models/items.js
+++ b/common/models/items.js
@@ -12,10 +12,19 @@ module.exports = function(Items) {
 		* Allow if creatorId is same as current user id
 		* Allow if orgId is same as current user organisation
 		*/
-		Items.create = function(data, callback){
-			var self = this;
+    Items.create = function(){
+      var data, callback;
+      if (arguments && arguments.length>0) {
+        data = arguments[0];
+        var possibleCallbackArg = arguments[arguments.length-1]
+        if (typeof possibleCallbackArg === 'function') {
+          callback = possibleCallbackArg;
+        }
+      }
 
-			callback = callback || utils.createPromiseCallback();
+      var self = this;
+
+      callback = callback || utils.createPromiseCallback();
 
       // get current context
       var currentContext = loopback.getCurrentContext();

--- a/common/models/organisation.json
+++ b/common/models/organisation.json
@@ -89,7 +89,7 @@
     {
       "accessType": "EXECUTE",
       "principalType": "ROLE",
-      "principalId": "$owner",
+      "principalId": "$teamMember",
       "permission": "ALLOW",
       "property": "__get__items"
     },

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,4 @@
+global.Promise = require('bluebird');
 var loopback = require('loopback');
 var boot = require('loopback-boot');
 var Promise = require('bluebird');


### PR DESCRIPTION
1. set `global.promise`
2. fix method signature for create - a bunch of stuff isn't needed
3. mark code exit blocks with `return`
4. i don't even know why we would override `create` if we wanted to prevent REST access via "disable remote method" and the related method call like `org.items.create`was going to appropriately set foreign keys like `orgId` but i guess it doesn't autoset `creatorId`
